### PR TITLE
Patch for signedness in Base64 decoder when compiled for ARMv7

### DIFF
--- a/mimetic/codec/base64.cxx
+++ b/mimetic/codec/base64.cxx
@@ -8,12 +8,12 @@
 
 using namespace mimetic;
 
-const char Base64::sEncTable[] = 
+const signed char Base64::sEncTable[] = 
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "abcdefghijklmnopqrstuvwxyz"
     "0123456789+/=";
 
-const char Base64::sDecTable[] = {
+const signed char Base64::sDecTable[] = {
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,

--- a/mimetic/codec/base64.h
+++ b/mimetic/codec/base64.h
@@ -19,8 +19,8 @@ class Base64
     enum { LF = 0xA, CR = 0xD, NL = '\n' };
     enum { default_maxlen = 76 };
     enum { eq_sign = 100 };
-    static const char sEncTable[];
-    static const char sDecTable[];
+    static const signed char sEncTable[];
+    static const signed char sDecTable[];
     static const int sDecTableSz;
 public:
     class Encoder; class Decoder;


### PR DESCRIPTION
Default signedness for char is platform depending. The base64 decoder expects char to be signed, but on ARMv7 it's unsigned. Therefore a check with == -1 fails and newline characters are not ignored on ARMv7. 