### PR TITLE
Add missing '+'

### DIFF
--- a/mimetic/rfc822/mailbox.cxx
+++ b/mimetic/rfc822/mailbox.cxx
@@ -40,7 +40,7 @@ std::string Mailbox::str() const
     {
         rs = m_label + " <";
         if(hasRoute)
-            rs = m_route+ ":";
+            rs += m_route+ ":";
     }
 
     rs += m_mailbox + "@" + m_domain;


### PR DESCRIPTION
        Label and '<' have gone if Mailbox has route.