### PR TITLE
Fix mail address parsing problem

### DIFF
--- a/mimetic/rfc822/group.cxx
+++ b/mimetic/rfc822/group.cxx
@@ -96,7 +96,8 @@ void Group::set(const string& text)
         } 
     }
     // trailing ';' missing
-    push_back(Mailbox(string(start, p-1)));
+    if(start <= (p-1))
+        push_back(Mailbox(string(start, p-1)));
 }
 
 string Group::name(int bCanonical) const

--- a/test/t.rfc822.cxx
+++ b/test/t.rfc822.cxx
@@ -154,6 +154,9 @@ void testRfc822::testAddress()
     b.set("group label: ;");
     TEST_ASSERT(b.isGroup());
 
+    b.set("undisclosed-recipient:");
+    TEST_ASSERT(b.isGroup());
+
 }
 
 


### PR DESCRIPTION
    Segfault occur if last character of mail address is colon.
    (missing semicolon case)
     ex) To: undisclosed-recipient: