### PR TITLE
Change output of Lf2CrLf codec to CRLF if input is CRLF.

### DIFF
--- a/mimetic/codec/other_codecs.h
+++ b/mimetic/codec/other_codecs.h
@@ -81,21 +81,28 @@ struct ToLowerCase: public unbuffered_codec, public chainable_codec<ToLowerCase>
  */
 struct Lf2CrLf: public unbuffered_codec, public chainable_codec<Lf2CrLf>
 {
+    Lf2CrLf()
+    : m_prev('\0')
+    {
+    }
     template<typename OutIt>
     void process(char c, OutIt& out)
     {
         enum { LF = 0xA, CR = 0xD };
-        if(c == LF)
+        if(c == LF && m_prev != CR)
         {
             *out = CR; ++out;
             *out = LF; ++out; 
         } else
             *out = c; ++out;
+        m_prev = c;
     }
     const char* name() const
     {    
         return "Lf2CrLf"; 
     }
+private:
+    char m_prev;
 };
 
 /// Inserts a new line if the input line is too long

--- a/test/t.codec.cxx
+++ b/test/t.codec.cxx
@@ -15,14 +15,50 @@ using namespace std;
 
 void test_codec::one()
 {
-    ToUpperCase tue;
-    MaxLineLen mll(44);
-    Base64::Encoder b64e;
-    QP::Encoder qpe;
     Base64::Decoder b64d;
     string o;
     string s("YWJjZGUBZmdoaQJsbW5vA3BxcgRzdHUFdno=");
     code(s.begin(),s.end(), b64d , back_inserter(o));
+}
+
+void test_codec::lf2crlf()
+{
+    Lf2CrLf l2cl;
+    string src("a\nb\r\nc\n\n");
+    string exp("a\r\nb\r\nc\r\n\r\n");
+    string got;
+    code(src.begin(), src.end(), l2cl , back_inserter(got));
+    TEST_ASSERT_EQUALS_P(exp, got);
+}
+
+void test_codec::toUpper()
+{
+    ToUpperCase tue;
+    string src("abc=\n");
+    string exp("ABC=\n");
+    string got;
+    code(src.begin(), src.end(), tue , back_inserter(got));
+    TEST_ASSERT_EQUALS_P(exp, got);
+}
+
+void test_codec::toLower()
+{
+    ToLowerCase tle;
+    string src("ABC=\n");
+    string exp("abc=\n");
+    string got;
+    code(src.begin(), src.end(), tle , back_inserter(got));
+    TEST_ASSERT_EQUALS_P(exp, got);
+}
+
+void test_codec::maxLine()
+{
+    MaxLineLen mll(4);
+    string src("abcdefghij");
+    string exp("abcd\r\nefgh\r\nij");
+    string got;
+    code(src.begin(), src.end(), mll , back_inserter(got));
+    TEST_ASSERT_EQUALS_P(exp, got);
 }
 
 }

--- a/test/t.codec.h
+++ b/test/t.codec.h
@@ -10,6 +10,10 @@ namespace mimetic
 struct TEST_CLASS( test_codec )
 {
     void TEST_FUNCTION( one );
+    void TEST_FUNCTION( lf2crlf );
+    void TEST_FUNCTION( toUpper );
+    void TEST_FUNCTION( toLower);
+    void TEST_FUNCTION( maxLine );
 };
 
 }


### PR DESCRIPTION
        - Changing codec behavior.
           before : LF -> CRLF, CRLF -> CRCRLF
           now : LF -> CRLF, CRLF -> CRLF
        - Add other_codecs test cases.

        Maybe changing CRLF to CRCRLF is not the behavior we want to.
        And unix2dos tool also decodes like above.