### PR TITLE
Cross compilation fix

### DIFF
--- a/mimetic/codec/base64.cxx
+++ b/mimetic/codec/base64.cxx
@@ -13,7 +13,7 @@ const char Base64::sEncTable[] =
     "abcdefghijklmnopqrstuvwxyz"
     "0123456789+/=";
 
-const char Base64::sDecTable[] = {
+const signed char Base64::sDecTable[] = {
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
         -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,

--- a/mimetic/codec/base64.h
+++ b/mimetic/codec/base64.h
@@ -20,7 +20,7 @@ class Base64
     enum { default_maxlen = 76 };
     enum { eq_sign = 100 };
     static const char sEncTable[];
-    static const char sDecTable[];
+    static const signed char sDecTable[];
     static const int sDecTableSz;
 public:
     class Encoder; class Decoder;


### PR DESCRIPTION
This simple patch fixes cross compilation with gcc 7.3 on arm7-32bit and ppc-64bit.