### PR TITLE
Mimetic can't parses address if there are trailing spaces after '>'

### DIFF
--- a/mimetic/rfc822/mailbox.cxx
+++ b/mimetic/rfc822/mailbox.cxx
@@ -61,7 +61,9 @@ void Mailbox::set(const string& input)
     // the string::erase or/and we cannot cache begin() end()
 
     int t = input.length() -1;
-    if(input[t] == '>')
+    while(input[t] == ' ')
+        t--;
+    if(t > 0 && input[t] == '>')
     {
         bool in_dquote = false, in_comment = false;
         int endoff = t - 1;

--- a/test/t.rfc822.cxx
+++ b/test/t.rfc822.cxx
@@ -84,6 +84,7 @@ void testRfc822::testMailbox()
         { "<e(boom). (boo)d@mail.com>", "e.d", "mail.com", "", "" },
         { "Bella Ragga <e(boom). (boo)d@mail.com>", "e.d", 
           "mail.com", "Bella Ragga", "" },
+        { "<e@mail.com> ", "e", "mail.com", "", "" },
         { 0,0,0,0,0 }
         };
     // test parser


### PR DESCRIPTION

	Removing trailing spaces of input address.
	Adding test case.