### PR TITLE
Disable default copy constructor for MimeEntity

### DIFF
--- a/mimetic/mimeentity.h
+++ b/mimetic/mimeentity.h
@@ -55,6 +55,9 @@ public:
      */
     MimeEntity(std::istream&);
 
+    MimeEntity(const MimeEntity&) = delete;
+    MimeEntity& operator=(const MimeEntity&) = delete;
+
     virtual ~MimeEntity();
 
     /**


### PR DESCRIPTION
MimeEntity contains a list of pointers to parts which are cleared in the constructor. Therefore the default constructor is not safe, as the pointers would be freed twice. Therefore disabled the default copy constructor in this patch.