### PR TITLE
Fix possible out of bound when removing new line characters

### DIFF
--- a/mimetic/parser/itparser.h
+++ b/mimetic/parser/itparser.h
@@ -718,8 +718,8 @@ private:
                 if(block_sz)
                 {
                     Iterator p = base + block_sz;
-                    char a = *--p, b = *--p;
-                    if(isnl(a,b))
+                    char a = *--p;
+                    if(block_sz>=2 && isnl(a,*--p))
                         block_sz -= 2;
                     else if(isnl(a))
                         block_sz--;


### PR DESCRIPTION
During fuzzy testing mimetic, we found an issue regarding the removal of new line characters. There is a possible variable underflow when removing new lines (itparser.h:726) which causes an exception by std::string because the end is before the beginning. This exception results also in a lot of memory being leaked.

There is a similar implementation in itparser.h:540 which is doing the check correctly.

Here is a mime message which provokes the issue, I've used the clang address sanitizer to also see the memory leaks.
[multi-invalid_mem_leak.msg.gz](https://github.com/tat/mimetic/files/5372304/multi-invalid_mem_leak.msg.gz)

Patch is quite simple. It just checks if the buffer is at least two bytes in size, before removing the new lines. (Also thanks to @obatysh for the patch)