### PR TITLE
Mimetic can't parses address if there are '\"' character in quoted-pair.

### DIFF
--- a/mimetic/rfc822/addresslist.cxx
+++ b/mimetic/rfc822/addresslist.cxx
@@ -57,6 +57,8 @@ void AddressList::set(const string& text)
             blanks = 0;
         } else if(*p == ' ') {
             blanks++;
+        } else if(p != text.end()-1 && *p == '\\' && *(p+1) == '"') {
+            p++;
         }
     }
     if( (p-beg) != blanks)// not a only-blanks-string

--- a/test/t.rfc822.cxx
+++ b/test/t.rfc822.cxx
@@ -160,5 +160,23 @@ void testRfc822::testAddress()
 
 }
 
+void testRfc822::testAddressList()
+{
+    const char* str1 = "\"rcpt1\" <rcpt1@mail.com>";
+    const char* str2 = "\"\\\"rcpt2, abc\\\"\" <rcpt2@mail.com>";
+    const char* str3 = "rcpt3 <rcpt3@mail.com>";
+    const char* delimiter = ",";
+
+    AddressList aList(string(str1) + delimiter + str2 + delimiter + str3);
+/*
+    AddressList::const_iterator bit(aList.begin()), eit(aList.end());
+    for(; bit != eit; ++bit)
+    {
+        cout <<  *bit << endl;
+    }
+*/
+    TEST_ASSERT_EQUALS_P(aList.size(), 3);
+}
+
 
 }

--- a/test/t.rfc822.h
+++ b/test/t.rfc822.h
@@ -10,6 +10,7 @@ namespace mimetic
 struct TEST_CLASS( testRfc822 )
 {
     void TEST_FUNCTION( testAddress );
+    void TEST_FUNCTION( testAddressList );
     void TEST_FUNCTION( testMailbox );
     void TEST_FUNCTION( testGroup );
 };


### PR DESCRIPTION
ex) To: "\"abc, def\"" <abc@mail.com>, lmn <lmn@mail.com>