### PR TITLE
Use unsigned int instead of uint

### DIFF
--- a/mimetic/codec/other_codecs.h
+++ b/mimetic/codec/other_codecs.h
@@ -117,7 +117,7 @@ struct MaxLineLen: public unbuffered_codec, public chainable_codec<MaxLineLen>
     : m_max(0), m_written(0)
     {
     }
-    MaxLineLen(uint m)
+    MaxLineLen(unsigned int m)
     : m_max(m), m_written(0)
     {
     }

--- a/mimetic/contenttype.cxx
+++ b/mimetic/contenttype.cxx
@@ -34,7 +34,7 @@ ContentType::Boundary::Boundary()
         stringstream ss;
         srand(time(0));
         short tbSize = sizeof(tb)-1;
-        for(uint i=0; i < 48; ++i)
+        for(unsigned int i=0; i < 48; ++i)
         {
             unsigned int r = rand();
             ss << tb[r % tbSize];


### PR DESCRIPTION
Improves portability by avoiding the non-standard uint. For example
this fixes building with musl libc:

"../mimetic/codec/other_codecs.h:112:20: error: expected ')' before 'm'
  112 |     MaxLineLen(uint m)
      |               ~    ^~
      |                    )"