### PR TITLE
Modify wrong memory reference

### DIFF
--- a/mimetic/strutils.cxx
+++ b/mimetic/strutils.cxx
@@ -24,6 +24,10 @@ string canonical(const string& s, bool no_ws)
         idx++;
     if(idx)
         input.erase(0, idx);
+
+    if(input.empty())
+        return input;
+
     // removes trailing spaces
     idx = input.length() - 1;
     while(input[idx] == ' ')


### PR DESCRIPTION
 - If input is a string of only spaces,
   index becomes -1 during removes trailing spaces operation,
   referencing the wrong memory.
 - If the referenced memory value is a space,
   out_of_range occurs
   because -1 is entered in the erase function pos parameter.
 - Modify to return immediately if the input value is empty
   after the removes leading spaces operation.