### PR TITLE
Update base64.h

### DIFF
--- a/mimetic/codec/base64.h
+++ b/mimetic/codec/base64.h
@@ -191,7 +191,7 @@ public:
         for(; bit != eit; ++bit)
         {
             c = *bit; 
-            if(c > sDecTableSz || sDecTable[c] == -1)
+            if(c >= sDecTableSz || sDecTable[c] == -1)
                 continue; // malformed or newline
             m_ch[m_cidx++] = sDecTable[c]; 
             if(m_cidx < 4)
@@ -218,7 +218,7 @@ public:
     template<typename OutIt>
     void process(char_type c, OutIt& out)
     {
-        if(c > sDecTableSz || sDecTable[c] == -1)
+        if(c >= sDecTableSz || sDecTable[c] == -1)
             return; // malformed or newline
         m_ch[m_cidx++] = sDecTable[c];
         if(m_cidx < 4)


### PR DESCRIPTION
For our project there were fuzzing tests done. In this process two out of bounds read bugs were found in mimetic caused by wrong checks in base64.h.