### PR TITLE
Expand all appearances of uint to unsigned int

### DIFF
--- a/mimetic/codec/other_codecs.h
+++ b/mimetic/codec/other_codecs.h
@@ -109,7 +109,7 @@ struct MaxLineLen: public unbuffered_codec, public chainable_codec<MaxLineLen>
     : m_max(0), m_written(0)
     {
     }
-    MaxLineLen(uint m)
+    MaxLineLen(unsigned int m)
     : m_max(m), m_written(0)
     {
     }

--- a/mimetic/contenttype.cxx
+++ b/mimetic/contenttype.cxx
@@ -34,7 +34,7 @@ ContentType::Boundary::Boundary()
         stringstream ss;
         srand(time(0));
         short tbSize = sizeof(tb)-1;
-        for(uint i=0; i < 48; ++i)
+        for(unsigned int i=0; i < 48; ++i)
         {
             unsigned int r = rand();
             ss << tb[r % tbSize];

--- a/mimetic/libconfig.h
+++ b/mimetic/libconfig.h
@@ -15,7 +15,6 @@
 
 /* Mac OS X */
 #if defined(__APPLE__) && defined(__MACH__)
-typedef unsigned int uint;
 #ifdef HAVE_MIMETIC_CONFIG
 #include "config.h"
 #endif
@@ -29,7 +28,6 @@ typedef unsigned int uint;
 #include <io.h>
 #include <ctime>
 #include <cstdio>
-typedef unsigned int uint;
 #define CONFIG_WIN32
 #endif
 

--- a/mimetic/message.cxx
+++ b/mimetic/message.cxx
@@ -138,7 +138,7 @@ void ApplicationOctStream::type(const string& type)
     m_header.contentType(ct);
 }
 
-uint ApplicationOctStream::padding() const
+unsigned int ApplicationOctStream::padding() const
 {
     return utils::str2int(m_header.contentType().param("padding"));
 }

--- a/mimetic/message.h
+++ b/mimetic/message.h
@@ -107,7 +107,7 @@ struct ApplicationOctStream: public MimeEntity
     ApplicationOctStream(const std::string&, const Codec& c=Base64::Encoder());
     std::string type() const;
     void type(const std::string&);
-    uint padding() const;
+    unsigned int padding() const;
     void padding(unsigned int);
     bool operator()() const { return isValid(); }
     bool isValid() const { return m_status; }

--- a/mimetic/os/fileop.cxx
+++ b/mimetic/os/fileop.cxx
@@ -51,7 +51,7 @@ bool FileOp::exists(const string& fqn)
 }
 
 //static
-uint FileOp::size(const string& fqn)
+unsigned int FileOp::size(const string& fqn)
 {
     struct stat st;
     if(::stat(fqn.c_str(), &st) == 0)
@@ -61,7 +61,7 @@ uint FileOp::size(const string& fqn)
 }
 
 //static
-uint FileOp::ctime(const string& fqn)
+unsigned int FileOp::ctime(const string& fqn)
 {
     struct stat st;
     if(::stat(fqn.c_str(), &st) == 0)
@@ -71,7 +71,7 @@ uint FileOp::ctime(const string& fqn)
 }
 
 //static
-uint FileOp::atime(const string& fqn)
+unsigned int FileOp::atime(const string& fqn)
 {
     struct stat st;
     if(::stat(fqn.c_str(), &st) == 0)
@@ -81,7 +81,7 @@ uint FileOp::atime(const string& fqn)
 }
 
 //static
-uint FileOp::mtime(const string& fqn)
+unsigned int FileOp::mtime(const string& fqn)
 {
     struct stat st;
     if(::stat(fqn.c_str(), &st) == 0)

--- a/mimetic/os/fileop.h
+++ b/mimetic/os/fileop.h
@@ -17,16 +17,15 @@ namespace mimetic
 /// Defines some file utility functions
 struct FileOp
 {
-    typedef unsigned int uint;
     /* static funtions */
     static bool remove(const std::string&);
     static bool move(const std::string&, const std::string&);
     static bool exists(const std::string&);
 
-    static uint size(const std::string&);
-    static uint ctime(const std::string&); // creation time
-    static uint atime(const std::string&); // last time accessed(r/w)
-    static uint mtime(const std::string&); // last time written
+    static unsigned int size(const std::string&);
+    static unsigned int ctime(const std::string&); // creation time
+    static unsigned int atime(const std::string&); // last time accessed(r/w)
+    static unsigned int mtime(const std::string&); // last time written
 };
 
 }

--- a/mimetic/os/mmfile.cxx
+++ b/mimetic/os/mmfile.cxx
@@ -97,7 +97,7 @@ MMFile::const_iterator MMFile::end() const
     return m_end;
 }
 
-uint MMFile::read(char* buf, int bufsz)
+unsigned int MMFile::read(char* buf, int bufsz)
 {
     int r;
     do

--- a/mimetic/os/mmfile.h
+++ b/mimetic/os/mmfile.h
@@ -28,7 +28,7 @@ struct MMFile: public FileOp
     operator bool() const;
     bool open(const std::string&, int mode = O_RDONLY);
     void close();
-    uint read(char*, int);
+    unsigned int read(char*, int);
 
     iterator begin();
     const_iterator begin() const;

--- a/mimetic/os/stdfile.cxx
+++ b/mimetic/os/stdfile.cxx
@@ -70,7 +70,7 @@ StdFile::iterator StdFile::end()
     return iterator();
 }
 
-uint StdFile::read(char* buf, int bufsz)
+unsigned int StdFile::read(char* buf, int bufsz)
 {
     int r;
     do

--- a/mimetic/os/stdfile.h
+++ b/mimetic/os/stdfile.h
@@ -28,7 +28,7 @@ struct StdFile: public FileOp
     operator bool() const;
     void open(const std::string&, int mode = O_RDONLY);
     void close();
-    uint read(char*, int);
+    unsigned int read(char*, int);
 
     iterator begin();
     iterator end();

--- a/test/cutee.cxx
+++ b/test/cutee.cxx
@@ -225,7 +225,7 @@ struct GenRunTest
             _( "    run_" << *beg << "();" );
         _( "    tearDown();" );
         _( "  }" );
-        _( "  uint count() { return " << m_fnList.size() << "; }" );
+        _( "  unsigned int count() { return " << m_fnList.size() << "; }" );
         _( "};" );
         _("static struct "<<cn<<"_add_to_list: public cutee::TestList");
         _( "{" );

--- a/test/cutee.h
+++ b/test/cutee.h
@@ -12,8 +12,6 @@
 #include <iomanip>
 #include <stdarg.h>
 
-typedef unsigned int uint;
-
 #define CUTEE_VERSION "0.4.2"
 
 #define MAX_TEST_COUNT 1000
@@ -107,34 +105,34 @@ struct Context
     {}
     // class info
     const string& className() const    { return mClassName; }
-    uint classLineNo() const { return mClassLineNo; }
+    unsigned int classLineNo() const { return mClassLineNo; }
     const string& classFileName() const { return mClassFileName; }
     // filename
     const string& fileName() const { return mFileName; }
     // function info
     const string& functionName() const { return mFunctionName; }
-    uint functionLineNo() const { return mFunctionLineNo; }
+    unsigned int functionLineNo() const { return mFunctionLineNo; }
     // assertion info
     const string& expr() const { return mExpr; }
     const string& exprFileName() const { return mExprFileName; }
-    uint exprLineNo() const { return mExprLineNo; }
+    unsigned int exprLineNo() const { return mExprLineNo; }
 
     void className(const string& s) { mClassName = s; }
     void classFileName(const string& s) { mClassFileName = s; }
-    void classLineNo(uint i) { mClassLineNo = i; }
+    void classLineNo(unsigned int i) { mClassLineNo = i; }
 
     void filename(const string& s) { mFileName = s; }
 
     void functionName(const string& s) { mFunctionName = s; }
-    void functionLineNo(uint i) { mFunctionLineNo = i; }
+    void functionLineNo(unsigned int i) { mFunctionLineNo = i; }
 
     void expr(const string& s) { mExpr = s; }
     void exprFileName(const string& s) { mExprFileName = s; }
-    void exprLineNo(uint i) { mExprLineNo = i; }
+    void exprLineNo(unsigned int i) { mExprLineNo = i; }
 private:
     std::string mClassName, mClassFileName, mFunctionName, 
         mFileName, mExpr, mExprFileName;
-    uint mClassLineNo, mFunctionLineNo, mExprLineNo;
+    unsigned int mClassLineNo, mFunctionLineNo, mExprLineNo;
 };
 
 
@@ -183,7 +181,7 @@ struct CuteeTest: public cutee::Context
     void testRunMonitor(TestRunMonitor *evt) { mEvt = evt; }
     int passed() const  { return mFailed == 0; }
     virtual void run() = 0;
-    virtual uint count() = 0;
+    virtual unsigned int count() = 0;
 protected:
     void testAssert(int b)
     {
@@ -199,7 +197,7 @@ protected:
     }
 protected:
     TestRunMonitor *mEvt, mNullMonitor;
-    uint mFuncExitCode, mFailed;
+    unsigned int mFuncExitCode, mFailed;
 };
 
 
@@ -246,7 +244,7 @@ struct StatsMonitor: public TestRunMonitor
             mAssertFailed++;
     }
 protected:
-    uint mAssertPassed, mAssertFailed, mAssertCount, mFuncPassed,
+    unsigned int mAssertPassed, mAssertFailed, mAssertCount, mFuncPassed,
          mFuncFailed, mFuncCount, mClassPassed, mClassFailed, mClassCount;
 };
 

--- a/test/t.composite.h
+++ b/test/t.composite.h
@@ -18,14 +18,14 @@ class TEST_CLASS( test_composite )
     std::string uppercase(const std::string& s)
     {
         std::string r;
-        for(uint i=0;i<s.length();i++)
+        for(unsigned int i=0;i<s.length();i++)
             r+=toupper(s[i]);
         return r;
     }
     std::string lowercase(const std::string& s)
     {
         std::string r;
-        for(uint i=0;i<s.length();i++)
+        for(unsigned int i=0;i<s.length();i++)
             r+=tolower(s[i]);
         return r;
     }


### PR DESCRIPTION
This commit resolves a build issue with musl libc found in [Gentoo](https://bugs.gentoo.org/712624), where `uint` definition is not available in two places and simplest solution is to expand it to `unsigned int`.