### PR TITLE
find_mm access of memory outside of allocated space is fixed

### DIFF
--- a/mimetic/utils.h
+++ b/mimetic/utils.h
@@ -48,6 +48,7 @@ template<typename Iterator>
 Iterator find_bm(Iterator bit, Iterator eit, const std::string& word, const std::random_access_iterator_tag&)
 {
     int bLen = word.length();
+    int sourceLen = std::distance(bit, eit);
     const char* pWord = word.c_str();
     int i, t, shift[256];
     unsigned char c;
@@ -56,17 +57,17 @@ Iterator find_bm(Iterator bit, Iterator eit, const std::string& word, const std:
         shift[i] = bLen;
 
     for(i = 0; i < bLen; ++i)
-        shift[ (unsigned char) pWord[i] ] = bLen -i - 1;
+        shift[ static_cast<unsigned char>( pWord[i] ) ] = bLen -i - 1;
 
     for(i = t = bLen-1; t >= 0; --i, --t)
     {
-        if((bit + i) >= eit)
+        if (i >= sourceLen)
             return eit; 
 
         while((c = *(bit + i)) != pWord[t]) 
         {
             i += std::max(bLen-t, shift[c]);
-            if((bit + i) >= eit) return eit; 
+            if (i >= sourceLen) return eit; 
             t = bLen-1;
         }
     }


### PR DESCRIPTION
Do you accept pull requests? I use this library in my home project. It has bug with memory access (it is not appear during tests, but appears when memory allocated from heap). Comparison of pointers is not correct, if pointer points outsides of allocated memory and this memory is protected, the program fails with memory access violation (tested on Windows). Also program can receive memory from heap in the end of the memory address space, and comparison of addresses never get true result. Integer arithmetics does not have the problems.