### PR TITLE
Fix possible out of bound read in Base64 decoder

### DIFF
--- a/mimetic/codec/base64.h
+++ b/mimetic/codec/base64.h
@@ -193,7 +193,7 @@ public:
         for(; bit != eit; ++bit)
         {
             c = *bit; 
-            if(c > sDecTableSz || sDecTable[c] == -1)
+            if(c >= sDecTableSz || sDecTable[c] == -1)
                 continue; // malformed or newline
             m_ch[m_cidx++] = sDecTable[c]; 
             if(m_cidx < 4)
@@ -220,7 +220,7 @@ public:
     template<typename OutIt>
     void process(char_type c, OutIt& out)
     {
-        if(c > sDecTableSz || sDecTable[c] == -1)
+        if(c >= sDecTableSz || sDecTable[c] == -1)
             return; // malformed or newline
         m_ch[m_cidx++] = sDecTable[c];
         if(m_cidx < 4)

--- a/test/t.base64.cxx
+++ b/test/t.base64.cxx
@@ -35,3 +35,17 @@ const char* test_base64::test[][2] = {
 { "abcde\1fghi\2lmno\3pqr\4stu\5vz","YWJjZGUBZmdoaQJsbW5vA3BxcgRzdHUFdno="    },
 { 0, 0 }
 };
+
+/*
+ * only test decoder, invalid chars should be skipped
+ *
+ * test fields:
+ * expected decoded data        base64 encoded data including invalid chars (e.g. whitespace)
+ *
+ */
+const char* test_base64::test_invalid_input[][2] = {
+{ "abcdefghilmnopqrstuvz","Y WJ#jZGVm:Z2h&pb;G1ub3-Bxcn\nN0d$XZ6"    },
+// | is 124 (dec) which is exactly the size of Base64::sDecTableSz
+{ "abcdefghilmnopqrstuvz","YWJjZGVmZ2|hpbG1ub3BxcnN0dXZ6"    },
+{ 0, 0 }
+};

--- a/test/t.base64.h
+++ b/test/t.base64.h
@@ -12,6 +12,7 @@ namespace mimetic
 class TEST_CLASS( test_base64 )
 {
     static const char* test[][2];
+    static const char* test_invalid_input[][2];
 public:
     void TEST_FUNCTION( testEncode )
     {
@@ -50,6 +51,17 @@ public:
         {
             std::string src = test[i][1];
             std::string exp = test[i][0];
+            std::string got;
+            Base64::Decoder base64;
+            decode(src.begin(), src.end(),base64,std::back_inserter<std::string>(got));
+            TEST_ASSERT_EQUALS_P( exp, got);
+            i++;
+        }
+        i = 0;
+        while(test_invalid_input[i][1] != 0)
+        {
+            std::string src = test_invalid_input[i][1];
+            std::string exp = test_invalid_input[i][0];
             std::string got;
             Base64::Decoder base64;
             decode(src.begin(), src.end(),base64,std::back_inserter<std::string>(got));


### PR DESCRIPTION
This is an extended version of the patch that fschmidberger already provided here: #25 

There is a possible out of bounds read in Base64 decoder when the input contains a '|' character. 
I've also extended also the tests to show the behaviour.

Thanks and best regards,
Oliver