### PR TITLE
Update itparser.h

### DIFF
--- a/mimetic/parser/itparser.h
+++ b/mimetic/parser/itparser.h
@@ -654,7 +654,7 @@ private:
     using base_type::isnl;
     
     typedef TreeNode<char> BoundaryTree;
-    inline void onBlock(Iterator bit, int size, ParsingElem pe)
+    inline void onBlock(Iterator bit, size_t size, ParsingElem pe)
     {
         if(pe == peIgnore)
             return;


### PR DESCRIPTION
Unsigned to signed conversion results in out of range crashes for large body sizes.